### PR TITLE
Create .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# https://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+trim_trailing_whitespace = true
+
+[*.go]
+indent_size = 8
+indent_style = tab
+
+[*.js]
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
I think it'd be a good idea to add an `.editorconfig` to the projects root for contributors to easily see the code-formatting style as is common with most Open Source projects. This could help prevent issues with PRs using tabs instead of spaces etc.

This uses the same config as is used on the Hugo Docs repo: https://github.com/gohugoio/hugoDocs/blob/master/.editorconfig